### PR TITLE
Revert "Fix get-secretkey Note for MacOS (#525)"

### DIFF
--- a/sentry/templates/NOTES.txt
+++ b/sentry/templates/NOTES.txt
@@ -1,3 +1,3 @@
 * When running upgrades, make sure to give back the `system.secretKey` value.
 
-kubectl -n {{ .Release.Namespace }} get configmap {{ template "sentry.fullname" . }}-sentry -o go-template='{{ index .data "config.yml" }}' | awk '$1=="system.secret-key:" {print $2}' | tr -d '"'
+kubectl -n {{ .Release.Namespace }} get configmap {{ template "sentry.fullname" . }}-sentry -o json | grep -m1 -Po '(?<=system.secret-key: )[^\\]*'


### PR DESCRIPTION
This reverts commit 85172fbb7cd10ae0af97ec1b51c6725ec362e139.
