### PR TITLE
Fix yaml block style for create user script [PEX-32446]

### DIFF
--- a/sentry/templates/hooks/user-create.yaml
+++ b/sentry/templates/hooks/user-create.yaml
@@ -51,7 +51,7 @@ spec:
         # Create user but do not exit 1 when user already exists (exit code 3 from createuser command)
         # https://docs.sentry.io/server/cli/createuser/
         args:
-          - >
+          - |
             sentry createuser \
               --no-input \
               --superuser \


### PR DESCRIPTION
The empty lines in line 49 causes the error. The script snippet is apparently transformed from the original helm chart, as it ends up in `literal style` (\|), while the original version in the helm chart is in `folded style` (>). 
Not sure what in between caused the problem, but I guess using `literal style` might be able to avoid some style transformation which might have caused the empty line.

> Block Style Indicator: The block style indicates how newlines inside the block should behave. If you would like them to be kept as newlines, use the **literal style** , indicated by a pipe (\|). If instead you want them to be replaced by spaces, use the **folded style**, indicated by a right angle bracket (>). (To get a newline using the folded style, leave a blank line by putting two newlines in. Lines with extra indentation are also not folded.)


(from https://yaml-multiline.info/)